### PR TITLE
Allow cronitor.sh to support environments

### DIFF
--- a/cronitor.sh
+++ b/cronitor.sh
@@ -56,7 +56,6 @@ while getopts ":i:sSpt:eoa:E:" opt; do
     i)
       id=$OPTARG
       ;;
-
     E)
       environment=$OPTARG
       ;;


### PR DESCRIPTION
cronitor.sh can now take -E as an argument.